### PR TITLE
Automatic build of manifest list on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,16 @@ before_script:
   - docker version
   - docker buildx create --name moc_builder --use
 
-script:
-  - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
-  - docker buildx build -t fnndsc/ubuntu-python3 --platform "$TARGET_ARCH" --progress plain --push .
+jobs:
+  include:
+    - stage: build_only
+      if: branch != master
+      script: docker buildx build -t fnndsc/ubuntu-python3 --platform "$TARGET_ARCH" --progress plain .
+    - stage: build_and_push
+      if: branch = master
+      before_script: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
+      script: docker buildx build -t fnndsc/ubuntu-python3 --platform "$TARGET_ARCH" --progress plain --push .
+      after_script: docker logout
 
 after_script:
   - docker buildx rm
-  - docker logout

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@
 dist: bionic
 
 env:
-  - DOCKER_CLI_EXPERIMENTAL=enabled
-  - TARGET_ARCH=linux/amd64,linux/ppc64le
+  - DOCKER_CLI_EXPERIMENTAL=enabled TARGET_ARCH=linux/amd64,linux/ppc64le
 
 before_install:
   - sudo rm -rf /var/lib/apt/lists/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+# https://github.com/jdrouet/docker-on-ci/blob/master/.travis.yml
+
+dist: bionic
+
+env:
+  - DOCKER_CLI_EXPERIMENTAL=enabled
+  - TARGET_ARCH=linux/amd64,linux/ppc64le
+
+before_install:
+  - sudo rm -rf /var/lib/apt/lists/*
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - lsb_release -cs
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) edge"
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+  - docker run --rm --privileged multiarch/qemu-user-static:register --reset
+
+before_script:
+  - docker version
+  - docker buildx create --name moc_builder --use
+
+script:
+  - docker buildx build -t fnndsc/ubuntu-python3 --platform "$TARGET_ARCH" .
+
+after_script:
+  - docker buildx rm

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,11 @@ before_script:
 
 stages:
   - name: login
-    if: branch = master
+    if: branch = master AND type != pull_request
   - name: build_only
-    if: branch != master
+    if: branch != master OR type = pull_request
   - name: build_and_push
-    if: branch = master
+    if: branch = master AND type != pull_request
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,17 @@
+# Automatically build the fnndsc/ubuntu-python3 Docker image on x86_64 and PowerPC.
+# On master branch, the image is pushed to Dockerhub as fnndsc/ubuntu-python3:latest.
+# If the commit is tagged, then two tags are used: fnndsc/ubuntu-python3:latest and fnndsc/ubuntu-python3:<GIT_TAG>
+#
 # https://github.com/jdrouet/docker-on-ci/blob/master/.travis.yml
 # using aptman/qus instead of multiarch/qemu-user-static
-# to load qemu binariesfor ppc64le emulation
+# to load qemu binariesfor ppc64le emulation.
 
 dist: bionic
 language: shell
 os: linux
 
 env:
-  - DOCKER_CLI_EXPERIMENTAL=enabled TARGET_ARCH=linux/amd64,linux/ppc64le
+  - DOCKER_CLI_EXPERIMENTAL=enabled TARGET_ARCH=linux/amd64,linux/ppc64le IMAGE_TAG=fnndsc/ubuntu-python3
 
 before_install:
   - sudo rm -rf /var/lib/apt/lists/*
@@ -22,17 +26,27 @@ before_script:
   - docker version
   - docker buildx create --name moc_builder --use
 
+stages:
+  - name: login
+    if: branch = master
+  - name: build_only
+    if: branch != master
+  - name: build_and_push
+    if: branch = master
+
 jobs:
   include:
+    - stage: login
+      script: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
     - stage: build_only
-      if: branch != master
-      script: docker buildx build -t fnndsc/ubuntu-python3 --platform "$TARGET_ARCH" --progress plain .
+      script: docker buildx build --platform "$TARGET_ARCH" --progress plain -t $IMAGE_TAG .
     - stage: build_and_push
-      if: branch = master
-      script:
-        - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
-        - docker buildx build -t fnndsc/ubuntu-python3 --platform "$TARGET_ARCH" --progress plain --push .
-      after_script: docker logout
+      if: tag IS blank
+      script: docker buildx build --platform "$TARGET_ARCH" --progress plain -t $IMAGE_TAG --push .
+    - stage: build_and_push
+      if: tag IS present
+      script: docker buildx build --platform "$TARGET_ARCH" --progress plain -t $IMAGE_TAG -t "$IMAGE_TAG:$TRAVIS_TAG" --push .
 
 after_script:
   - docker buildx rm
+  - docker logout

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,3 +50,4 @@ jobs:
 after_script:
   - docker buildx rm
   - docker logout
+  - docker run --rm --privileged aptman/qus -- -r

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@
 # to load qemu binariesfor ppc64le emulation
 
 dist: bionic
+language: shell
+os: linux
 
 env:
   - DOCKER_CLI_EXPERIMENTAL=enabled TARGET_ARCH=linux/amd64,linux/ppc64le
@@ -27,8 +29,9 @@ jobs:
       script: docker buildx build -t fnndsc/ubuntu-python3 --platform "$TARGET_ARCH" --progress plain .
     - stage: build_and_push
       if: branch = master
-      before_script: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
-      script: docker buildx build -t fnndsc/ubuntu-python3 --platform "$TARGET_ARCH" --progress plain --push .
+      script:
+        - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
+        - docker buildx build -t fnndsc/ubuntu-python3 --platform "$TARGET_ARCH" --progress plain --push .
       after_script: docker logout
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,14 @@ before_install:
   - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) edge"
   - sudo apt-get update
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
-  - docker run --rm --privileged multiarch/qemu-user-static:register --reset
+  - docker run --rm --privileged aptman/qus -s -- -p ppc64le
 
 before_script:
   - docker version
   - docker buildx create --name moc_builder --use
 
 script:
-  - docker buildx build -t fnndsc/ubuntu-python3 --platform "$TARGET_ARCH" .
+  - docker buildx build -t fnndsc/ubuntu-python3 --platform "$TARGET_ARCH" --progress plain .
 
 after_script:
   - docker buildx rm

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,9 @@ before_script:
   - docker buildx create --name moc_builder --use
 
 script:
-  - docker buildx build -t fnndsc/ubuntu-python3 --platform "$TARGET_ARCH" --progress plain .
+  - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
+  - docker buildx build -t fnndsc/ubuntu-python3 --platform "$TARGET_ARCH" --progress plain --push .
 
 after_script:
   - docker buildx rm
+  - docker logout

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 # https://github.com/jdrouet/docker-on-ci/blob/master/.travis.yml
+# using aptman/qus instead of multiarch/qemu-user-static
+# to load qemu binariesfor ppc64le emulation
 
 dist: bionic
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,37 @@ Source for a slim Ubuntu-based Python3 image
 13-May-2020
 * Update for 20.04 (LTS) base image.
 
-# Manifest List
+## Manifest List
+
+Create a multi-architecture manifest list.
+
+### Background
+
+A single tag in a Docker registry (e.g. `docker.io/ubuntu:bionic` or `docker.io/fnndsc/ubuntu-python3:latest`) can refer to multiple images for different architectures. When a local docker engine executes `docker pull` or `FROM` in a Dockerfile, the correct image that matches the host's native architecture is used.
+
+Images that use `FROM fnndsc/ubuntu-python3:latest` in their Dockerfile (most `fnndsc/pl-*` plugins for ChRIS) can also be built for multiple architectures. You can simply build the same Dockerfile on different hosts without modification, or follow the [steps below](#build) to build cross-platform.
+
+Note that [Dockerhub cannot do autobuilds for non-x86_64 images.](https://github.com/docker/hub-feedback/issues/1779#issuecomment-478100972). Autobuilds from Dockerhub (again, most `fnndsc/pl-*`) are only for x86_64. `fnndsc/ubuntu-python3` is built using [Travis](#Travis-Automatic-Builds), which is a bit less convenient.
+
+### Build
+
+Linux x86_64 (check with `uname -sm`) can use QEMU emulation to do cross-platform builds for foreign architectures.
 
 First, make sure you have Docker CLI experimetnal features enabled.
+https://github.com/docker/buildx#docker-ce
 
 ```bash
 docker buildx create --name moc_builder --use
-docker buildx build -t fnndsc/ubuntu-python3:20.04 --platform linux/amd64,linux/ppc64le --push .
+docker buildx build -t fnndsc/ubuntu-python3 --platform linux/amd64,linux/ppc64le .
+# clean up
 docker buildx rm
+docker run --rm --privileged aptman/qus -- -r
 ```
+
+# Travis Automatic Builds
+
+[![Travis Badge](https://travis-ci.org/FNNDSC/ubuntu-python3.svg?branch=master)](https://travis-ci.org/github/FNNDSC/ubuntu-python3)
+
+Travis automatically builds and pushes [`master`](https://github.com/FNNDSC/ubuntu-python3/tree/master) branch to [Dockerhub](https://hub.docker.com/r/fnndsc/ubuntu-python3/tags) as `fnndsc/ubuntu-python3:latest`. This manifest list will contain images for x86_64 and PowerPC.
+
+If the latest commit is tagged (`git tag <tag_name>`), then the automatic build will also have that tag in addition (`fnndsc/ubuntu-python3:latest` and `fnndsc/ubuntu-python3:<tag_name>`).

--- a/README.md
+++ b/README.md
@@ -15,13 +15,19 @@ Source for a slim Ubuntu-based Python3 image
 
 Create a multi-architecture manifest list.
 
-### Background
+<details>
+<summary>
+<b>Background</b>
+</summary>
 
 A single tag in a Docker registry (e.g. `docker.io/ubuntu:bionic` or `docker.io/fnndsc/ubuntu-python3:latest`) can refer to multiple images for different architectures. When a local docker engine executes `docker pull` or `FROM` in a Dockerfile, the correct image that matches the host's native architecture is used.
 
 Images that use `FROM fnndsc/ubuntu-python3:latest` in their Dockerfile (most `fnndsc/pl-*` plugins for ChRIS) can also be built for multiple architectures. You can simply build the same Dockerfile on different hosts without modification, or follow the [steps below](#build) to build cross-platform.
 
 Note that [Dockerhub cannot do autobuilds for non-x86_64 images.](https://github.com/docker/hub-feedback/issues/1779#issuecomment-478100972). Autobuilds from Dockerhub (again, most `fnndsc/pl-*`) are only for x86_64. `fnndsc/ubuntu-python3` is built using [Travis](#Travis-Automatic-Builds), which is a bit less convenient.
+
+</details>
+
 
 ### Build
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Source for a slim Ubuntu-based Python3 image
 13-May-2020
 * Update for 20.04 (LTS) base image.
 
+26-May-2020
+* Automatic multiarch build on Travis.
+
 ## Manifest List
 
 Create a multi-architecture manifest list.

--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ docker run --rm --privileged aptman/qus -- -r
 
 Travis automatically builds and pushes [`master`](https://github.com/FNNDSC/ubuntu-python3/tree/master) branch to [Dockerhub](https://hub.docker.com/r/fnndsc/ubuntu-python3/tags) as `fnndsc/ubuntu-python3:latest`. This manifest list will contain images for x86_64 and PowerPC.
 
-If the latest commit is tagged (`git tag <tag_name>`), then the automatic build will also have that tag in addition (`fnndsc/ubuntu-python3:latest` and `fnndsc/ubuntu-python3:<tag_name>`).
+If the latest commit is tagged (`git tag <tag_name>`), then the automatic build will also have that tag in addition (`fnndsc/ubuntu-python3:latest` and `fnndsc/ubuntu-python3:<tag_name>`). In that case we should update https://github.com/FNNDSC/cookiecutter-chrisapp Dockerfile to use the new `fnndsc/ubuntu-python3:<tag_name>`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # ubuntu-python3
+
 Source for a slim Ubuntu-based Python3 image
 
 03-Aug-2018
@@ -6,3 +7,13 @@ Source for a slim Ubuntu-based Python3 image
 
 13-May-2020
 * Update for 20.04 (LTS) base image.
+
+# Manifest List
+
+First, make sure you have Docker CLI experimetnal features enabled.
+
+```bash
+docker buildx create --name moc_builder --use
+docker buildx build -t fnndsc/ubuntu-python3:20.04 --platform linux/amd64,linux/ppc64le --push .
+docker buildx rm
+```


### PR DESCRIPTION
Automatically build the `fnndsc/ubuntu-python3` Docker image on **x86_64** and **PowerPC**.

On master branch, the image is pushed to Dockerhub as f`nndsc/ubuntu-python3:latest`

If the commit is tagged, then two tags are used: `fnndsc/ubuntu-python3:latest` and `fnndsc/ubuntu-python3:<GIT_TAG>`